### PR TITLE
Identify interactive elements and display 

### DIFF
--- a/Code/MotorEase.py
+++ b/Code/MotorEase.py
@@ -72,9 +72,11 @@ def RunDetectors(data_folder):
 
 			# display xml code snippet for interactive elements
 			if touchTarget[1] > 0:
-				print("Interactive Elements: ")
-				for elem in touchTarget[3]:
-					print(elem)
+				print("===== Interactive Elements =====")
+
+				for index, elem in enumerate(touchTarget[3]):
+					print("Interactive Element #" + str(index+1) + ": " + str(elem) + "\n")
+					txt.write("Interactive Element #" + str(index+1) + ": " + str(elem) + "\n")
 				print("\n")
 
 			print("===== Running Expanding Elements =====")

--- a/Code/MotorEase.py
+++ b/Code/MotorEase.py
@@ -70,6 +70,13 @@ def RunDetectors(data_folder):
 			print(touchText)  
 			txt.write(touchText + '\n')  
 
+			# display xml code snippet for interactive elements
+			if touchTarget[1] > 0:
+				print("Interactive Elements: ")
+				for elem in touchTarget[3]:
+					print(elem)
+				print("\n")
+
 			print("===== Running Expanding Elements =====")
 			expanding = detectClosure(image, xml, glove_model_array)
 			expandingText = image + ":\n" + "Expanding Sections Detector>> " +"Expanding elements: " + str(expanding) + "\n"

--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -70,8 +70,10 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										width = data["compos"][i]['width']
 										if height < 48 or width < 48:
 											violations += 1
+											interactive_elements.append(elements)
 										else:
 											nonViolations += 1
+											interactive_elements.append(elements)
 
 										#print(violations)
 										#print(nonViolations)

--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -29,6 +29,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 		root = tree.getroot()
 		bounding_boxes = []
 		singleScreenViolations = []
+		interactive_elements = []
 
 		violations = 0
 		nonViolations = 0
@@ -42,6 +43,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 					first = bounds[1][0] - bounds[0][0]
 					second = bounds[1][1] - bounds[0][1]
 					if first <48 or second <48:
+						interactive_elements.append(elements)
 						#print(elements)
 						#print(bounds)
 						violations+=1
@@ -78,12 +80,10 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										os.remove("./Code/detectors/Visual/UIED-master/data/output/ip/" + file_name)
 								else:
 									os.remove("./Code/detectors/Visual/UIED-master/data/output/ip/" +file_name)
-		return([violations, violations+nonViolations, xml_path])
+		return([violations, violations+nonViolations, xml_path, interactive_elements])
 										
 
 						#return([bounds, screenshot_path, elements])
-
-		
 
 
 

--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -69,11 +69,10 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										height = data["compos"][i]['height']
 										width = data["compos"][i]['width']
 										if height < 48 or width < 48:
-											violations += 1
-											interactive_elements.append(elements)
+											violations += 1	
 										else:
 											nonViolations += 1
-											interactive_elements.append(elements)
+										interactive_elements.append(elements)
 
 										#print(violations)
 										#print(nonViolations)

--- a/MotorEase.py
+++ b/MotorEase.py
@@ -69,6 +69,13 @@ def RunDetectors(data_folder):
 			touchText = "Touch Target Detector>> "  + "Interactive Elements: " + str(touchTarget[1]) + " | Violating Elements: " + str(touchTarget[0]) + "\n"
 			print(touchText)  
 			txt.write(touchText + '\n')  
+			
+			# display xml code snippet for interactive elements
+			if touchTarget[1] > 0:
+				print("Interactive Elements: ")
+				for elem in touchTarget[3]:
+					print(elem)
+				print("\n")
 
 			print("===== Running Expanding Elements =====")
 			expanding = detectClosure(image, xml, glove_model_array)

--- a/MotorEase.py
+++ b/MotorEase.py
@@ -69,12 +69,14 @@ def RunDetectors(data_folder):
 			touchText = "Touch Target Detector>> "  + "Interactive Elements: " + str(touchTarget[1]) + " | Violating Elements: " + str(touchTarget[0]) + "\n"
 			print(touchText)  
 			txt.write(touchText + '\n')  
-			
+
 			# display xml code snippet for interactive elements
 			if touchTarget[1] > 0:
-				print("Interactive Elements: ")
-				for elem in touchTarget[3]:
-					print(elem)
+				print("===== Interactive Elements =====")
+
+				for index, elem in enumerate(touchTarget[3]):
+					print("Interactive Element #" + str(index+1) + ": " + str(elem) + "\n")
+					txt.write("Interactive Element #" + str(index+1) + ": " + str(elem) + "\n")
 				print("\n")
 
 			print("===== Running Expanding Elements =====")


### PR DESCRIPTION
### Description:
Currently, the users are only able to see a count of Interactive Elements, making it hard to find which interactive elements from the screenshot and the extensive XML file. This issue focuses on identifying and displaying the XML snippets for the interactive elements in a screenshot. Fixes issue #6.

### Changes:
Changes made in `Code/detectors/Visual/TouchTarget.py`:
- Compiled a list of elements and returned with the violation and interactive element counts
_Reasoning_: The elements were being tracked already, so compiling the violating and non-violating elements and returning the list ensured that all the interactive elements were being tracked. 

Changes made in `MotorEase.py` / `Code/MotorEase.py`:
- Display Interactive Elements, if any
_Reasoning_: Sometimes there are no interactive elements on the page, so this will ensure that only when they are present will they be shown to the user, allowing for easier identification.

### Timeline
Engineering Points/Effort: 5 points (5 day's worth of work). This issue was resolved in Sprint 1. 

### Testing - Windows:
```
docker pull itsarunkv/motorease-amd
docker run -it --rm -v container_files:/container_files itsarunkv/motorease-amd /bin/bash

cd Code
python3 MotorEase.py
```

#### Manual Testing
1. Setup Docker environment
2. Run `python3 MotorEase.py` in the `Code` folder
3. After the Touch Target Detector Element counts, the list of `Interactive Elements` is shown with the XML code for the elements. If a screenshot image does not have any interactive elements, this section will not show. 
6. Here's a screenshot showcasing the list of interactive elements:
![image](https://github.com/hemkan/MotorEase/assets/92342649/3a366848-4019-4fb7-aeab-b421671f99be)

