### PR TITLE
Display Violating Elements (if any)

### DIFF
--- a/Code/MotorEase.py
+++ b/Code/MotorEase.py
@@ -70,17 +70,7 @@ def RunDetectors(data_folder):
 			print(touchText)  
 			txt.write(touchText + '\n')  
 
-			# Version 1
-			# # display xml code snippet for violating elements
-			# if touchTarget[1] > 0:
-			# 	print("===== Violating Elements =====")
-
-			# 	for index, elem in enumerate(touchTarget[3]):
-			# 		print("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
-			# 		txt.write("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
-			# 	print("\n")
-   
-			# Version 2
+			# display xml code snippet for violating elements
 			if touchTarget[1] > 0:
 				print("===== Interactive Elements =====")
 

--- a/Code/MotorEase.py
+++ b/Code/MotorEase.py
@@ -70,6 +70,15 @@ def RunDetectors(data_folder):
 			print(touchText)  
 			txt.write(touchText + '\n')  
 
+			# display xml code snippet for interactive elements
+			if touchTarget[1] > 0:
+				print("===== Violating Elements =====")
+
+				for index, elem in enumerate(touchTarget[3]):
+					print("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
+					txt.write("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
+				print("\n")
+
 			print("===== Running Expanding Elements =====")
 			expanding = detectClosure(image, xml, glove_model_array)
 			expandingText = image + ":\n" + "Expanding Sections Detector>> " +"Expanding elements: " + str(expanding) + "\n"

--- a/Code/MotorEase.py
+++ b/Code/MotorEase.py
@@ -70,7 +70,7 @@ def RunDetectors(data_folder):
 			print(touchText)  
 			txt.write(touchText + '\n')  
 
-			# display xml code snippet for interactive elements
+			# display xml code snippet for violating elements
 			if touchTarget[1] > 0:
 				print("===== Violating Elements =====")
 

--- a/Code/MotorEase.py
+++ b/Code/MotorEase.py
@@ -70,13 +70,27 @@ def RunDetectors(data_folder):
 			print(touchText)  
 			txt.write(touchText + '\n')  
 
-			# display xml code snippet for violating elements
+			# Version 1
+			# # display xml code snippet for violating elements
+			# if touchTarget[1] > 0:
+			# 	print("===== Violating Elements =====")
+
+			# 	for index, elem in enumerate(touchTarget[3]):
+			# 		print("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
+			# 		txt.write("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
+			# 	print("\n")
+   
+			# Version 2
 			if touchTarget[1] > 0:
-				print("===== Violating Elements =====")
+				print("===== Interactive Elements =====")
 
 				for index, elem in enumerate(touchTarget[3]):
-					print("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
-					txt.write("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
+					if elem[1] == 0:
+						print("Interactive Element #" + str(index+1) + ": \n" + str(elem[0]) + "\n")
+						txt.write("Interactive Element #" + str(index+1) + ": \n" + str(elem[0]) + "\n")
+					elif elem[1] == 1:
+						print("Interactive Element #" + str(index+1) + ": \n**[VIOLATION]** " + str(elem[0]) + "\n")
+						txt.write("Interactive Element #" + str(index+1) + ": \n**[VIOLATION]** " + str(elem[0]) + "\n")
 				print("\n")
 
 			print("===== Running Expanding Elements =====")

--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -29,6 +29,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 		root = tree.getroot()
 		bounding_boxes = []
 		singleScreenViolations = []
+		violatingElements = []
 
 		violations = 0
 		nonViolations = 0
@@ -44,6 +45,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 					if first <48 or second <48:
 						#print(elements)
 						#print(bounds)
+						violatingElements.append(elements)
 						violations+=1
 
 					else:
@@ -68,6 +70,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										width = data["compos"][i]['width']
 										if height < 48 or width < 48:
 											violations += 1
+											violatingElements.append(elements)
 										else:
 											nonViolations += 1
 
@@ -78,7 +81,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										os.remove("./Code/detectors/Visual/UIED-master/data/output/ip/" + file_name)
 								else:
 									os.remove("./Code/detectors/Visual/UIED-master/data/output/ip/" +file_name)
-		return([violations, violations+nonViolations, xml_path])
+		return([violations, violations+nonViolations, xml_path, violatingElements])
 										
 
 						#return([bounds, screenshot_path, elements])

--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -29,6 +29,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 		root = tree.getroot()
 		bounding_boxes = []
 		singleScreenViolations = []
+		interactiveElements = []
 		violatingElements = []
 
 		violations = 0
@@ -45,6 +46,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 					if first <48 or second <48:
 						#print(elements)
 						#print(bounds)
+						interactiveElements.append([elements, 1])
 						violatingElements.append(elements)
 						violations+=1
 
@@ -70,9 +72,12 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										width = data["compos"][i]['width']
 										if height < 48 or width < 48:
 											violations += 1
+											interactiveElements.append([elements, 1])
 											violatingElements.append(elements)
 										else:
 											nonViolations += 1
+											interactiveElements.append([elements, 1])
+											
 
 										#print(violations)
 										#print(nonViolations)
@@ -81,7 +86,9 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										os.remove("./Code/detectors/Visual/UIED-master/data/output/ip/" + file_name)
 								else:
 									os.remove("./Code/detectors/Visual/UIED-master/data/output/ip/" +file_name)
-		return([violations, violations+nonViolations, xml_path, violatingElements])
+		# return([violations, violations+nonViolations, xml_path, violatingElements])
+		return([violations, violations+nonViolations, xml_path, interactiveElements])
+
 										
 
 						#return([bounds, screenshot_path, elements])

--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -76,7 +76,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 											violatingElements.append(elements)
 										else:
 											nonViolations += 1
-											interactiveElements.append([elements, 1])
+											interactiveElements.append([elements, 0])
 											
 
 										#print(violations)

--- a/MotorEase.py
+++ b/MotorEase.py
@@ -70,6 +70,29 @@ def RunDetectors(data_folder):
 			print(touchText)  
 			txt.write(touchText + '\n')  
 
+			# Version 1
+			# # display xml code snippet for violating elements
+			# if touchTarget[1] > 0:
+			# 	print("===== Violating Elements =====")
+
+			# 	for index, elem in enumerate(touchTarget[3]):
+			# 		print("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
+			# 		txt.write("Violating Element #" + str(index+1) + ": " + str(elem) + "\n")
+			# 	print("\n")
+   
+			# Version 2
+			if touchTarget[1] > 0:
+				print("===== Interactive Elements =====")
+
+				for index, elem in enumerate(touchTarget[3]):
+					if elem[1] == 0:
+						print("Interactive Element #" + str(index+1) + ": \n" + str(elem[0]) + "\n")
+						txt.write("Interactive Element #" + str(index+1) + ": \n" + str(elem[0]) + "\n")
+					elif elem[1] == 1:
+						print("Interactive Element #" + str(index+1) + ": \n**[VIOLATION]** " + str(elem[0]) + "\n")
+						txt.write("Interactive Element #" + str(index+1) + ": \n**[VIOLATION]** " + str(elem[0]) + "\n")
+				print("\n")
+
 			print("===== Running Expanding Elements =====")
 			expanding = detectClosure(image, xml, glove_model_array)
 			expandingText = image + ":\n" + "Expanding Sections Detector>> " +"Expanding elements: " + str(expanding) + "\n"


### PR DESCRIPTION
### Description:
The users are only able to see the number of violating elements. To gain more insight as to which these elements are, they would need to go through the XML file and track the interactive elements first and then find which ones violate the guidelines. This issue focuses on identifying and displaying the XML snippets for the violating elements. Fixes issue #1.

### Changes:
Changes made in `Code/detectors/Visual/TouchTarget.py`:
- Find where violating elements are being detected for the count to update and compile the associated snippets and return them
_Reasoning_: This will track all the violated elements as they are being detected and return a compilation of them at the end. 

Changes made in `MotorEase.py` / `Code/MotorEase.py`:
- Display/Label Violating Elements sections if any violating elements exist
_Reasoning_: There are 2 versions of this where given a list of interactive elements from #11, the violated elements are labeled, or a separate section with violating elements is listed. Version 2 is more considerate of user experience as it removes redundancy. 

### Timeline
Engineering Points/Effort: 3 points (3 day's worth of work). This issue was resolved in Sprint 2. 

### Testing - Windows:
```
docker pull itsarunkv/motorease-amd
docker run -it --rm -v container_files:/container_files itsarunkv/motorease-amd /bin/bash

cd Code
python3 MotorEase.py
```

#### Manual Testing
1. Setup Docker environment
2. Run `python3 MotorEase.py` in the `Code` folder
3. After the Touch Target Detector Element counts, the list of `Violating Elements` is shown with the XML code for the elements. If no such elements exist, this section will not show. 
6. **_Version 1_**: Here's a screenshot showcasing the list of violating elements:
![image](https://github.com/hemkan/MotorEase/assets/92342649/47c92401-9211-4fc3-ab30-5ff98b639244)
**_Version 2_**: Here's a screenshot showcasing labeled violating elements from a list of interactive elements
![image](https://github.com/hemkan/MotorEase/assets/92342649/c70a8441-42d2-4dc2-87ee-4b16db4ebb7f)