### PR TITLE
Fix bug for getting elements

### DIFF
--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -82,7 +82,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										os.remove("/code/detectors/Visual/UIED-master/data/output/ip/" + file_name)
 								else:
 									os.remove("/code/detectors/Visual/UIED-master/data/output/ip/" +file_name)
-		return([violations, violations+nonViolations, xml_path])
+		return([violations, violations+nonViolations, xml_path, interactiveElements])
 									
 										
 


### PR DESCRIPTION
### Description:
Previously, main gives the following error on running `python3 MotorEase.py`:
![image](https://github.com/hemkan/MotorEase/assets/92342649/49225bdb-0f40-44c2-bc81-9f6678a9396c)

This PR fixes this issue. Fixes #22.

### Changes:
Changes made in `Code/detectors/Visual/TouchTarget.py`:
- added the interactiveElements list to the return statement to ensure it is safely received by `Code/MotorEase.py`

### Timeline
Engineering Points/Effort: 1 points (1 day's worth of work). This issue was resolved in Sprint 2. 


### Testing - Windows:
```
docker pull itsarunkv/motorease-amd
docker run -it --rm -v container_files:/container_files itsarunkv/motorease-amd /bin/bash

cd Code
python3 MotorEase.py
```
#### Manual Testing
1. Setup Docker environment
2. Run `python3 MotorEase.py` in the `Code` folder
3. After the Touch Target Detector Element counts, the list of `Violating Elements` is shown with the XML code for the elements. If no such elements exist, this section will not show. 
6. Here's a screenshot showcasing that the program runs and the violating elements are marked within the list of interactive elements: 
![image](https://github.com/hemkan/MotorEase/assets/92342649/a12eb13e-c81c-40cf-8b23-a17bd6451da7)
