### PR TITLE
Translate violating components from Android Syntax to English

### DIFF
--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -81,7 +81,7 @@ def describeBounds(bounds, height, width):
 
 	return position_description
 
-def desribe(xml_element):
+def describe_violating(xml_element):
 	bounds = xml_element.attrib.get('bounds', '')
 	text = xml_element.attrib.get('text', '')
 	component = xml_element.attrib.get('class', '')
@@ -90,9 +90,9 @@ def desribe(xml_element):
 	# Assuming the screen resolution
 	screen_height = 1920
 	screen_width = 1080
-	position_description = describeBounds(bounds)
+	position_description = describeBounds(bounds, screen_height, screen_width)
 
-	print("This component is a {} with text '{}'.".format(component_str, text))
+	print("This violating component is a {} with text '{}'.".format(component_str, text))
 	print(position_description)
 
 def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
@@ -119,7 +119,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 						#print(elements)
 						#print(bounds)
 						interactiveElements.append([elements, 1])
-						describe(elem)
+						describe_violating(elem)
 						violations+=1
 
 					else:
@@ -143,6 +143,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										height = data["compos"][i]['height']
 										width = data["compos"][i]['width']
 										if height < 48 or width < 48:
+											describe_violating(elem)
 											violations += 1
 											interactiveElements.append([elements, 1])
 										else:

--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -22,6 +22,79 @@ def getBounds(inText):
     split[1] = [int(split[1][0]), int(split[1][1])]
     return split
 
+def describeWidgetComponent(class_name):
+    lower_class_name = class_name.lower()
+
+    # Dictionary mapping class names to descriptions
+    widget_map = {
+        'android.widget.button': "Button",
+        'android.widget.checkbox': "Checkbox",
+        'android.widget.radiobutton': "Radio button",
+        'android.widget.switch': "Switch",
+        'android.widget.edittext': "Edit text",
+        'android.widget.imageview': "Image view",
+        'android.widget.progressbar': "Progress bar",
+        'android.widget.seekbar': "Seekbar",
+        'android.widget.spinner': "Spinner",
+        'android.widget.listview': "List view",
+        'android.widget.gridview': "Grid view",
+        'android.widget.linearlayout': "Linear layout",
+        'android.widget.framelayout': "Frame layout",
+        'android.widget.relativelayout': "Relative layout",
+        'android.widget.toolbar': "Toolbar",
+        'android.widget.imagebutton': "Image button",
+        'android.widget.scrollview': "Scroll view",
+        'android.view.view': "View",
+        'android.view.viewgroup': "View group",
+    }
+
+    if lower_class_name in widget_map:
+       return widget_map[lower_class_name]
+
+    return "Unknown widget component"
+
+def describeBounds(bounds, height, width):
+	bounds_values = bounds.strip('[]').split(',')
+	left = int(bounds_values[0])
+	top = int(bounds_values[1].split('][')[0])
+	right = int(bounds_values[-1])
+	bottom = int(bounds_values[-1].split('][')[-1])
+
+	center_x = (left + right) // 2
+	center_y = (top + bottom) // 2
+
+	if center_x < width / 2:
+		horizontal_position = "left"
+	elif center_x > width / 2:
+		horizontal_position = "right"
+	else:
+		horizontal_position = "center"
+
+	if center_y < height / 2:
+		vertical_position = "top"
+	elif center_x > height / 2:
+		vertical_position = "bottom"
+	else:
+		vertical_position = "center"
+
+	position_description = "The element is potions towards the {}-{} corner of the screen.".format(vertical_position, horizontal_position)
+
+	return position_description
+
+def desribe(xml_element):
+	bounds = xml_element.attrib.get('bounds', '')
+	text = xml_element.attrib.get('text', '')
+	component = xml_element.attrib.get('class', '')
+	component_str = describeWidgetComponent(component)
+
+	# Assuming the screen resolution
+	screen_height = 1920
+	screen_width = 1080
+	position_description = describeBounds(bounds)
+
+	print("This component is a {} with text '{}'.".format(component_str, text))
+	print(position_description)
+
 def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 # Load the XML file
 	if ".DS_S" not in xml_path:
@@ -46,6 +119,7 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 						#print(elements)
 						#print(bounds)
 						interactiveElements.append([elements, 1])
+						describe(elem)
 						violations+=1
 
 					else:

--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -77,7 +77,7 @@ def describeBounds(bounds, height, width):
 	else:
 		vertical_position = "center"
 
-	position_description = "The element is potions towards the {}-{} corner of the screen.".format(vertical_position, horizontal_position)
+	position_description = "The element is positioned towards the {}-{} corner of the screen.".format(vertical_position, horizontal_position)
 
 	return position_description
 


### PR DESCRIPTION
### Description:
Currently, the elements that are labeled as violating are printed out but in XML format. This format can be difficult for users to understand and this PR translates violating elements from Android Syntax to English. Resolves #7.

### Changes:
The changes are made in ` Code/detectors/Visual/TouchTarget.py` and introduce 3 new functions.
- `describeWidgetComponent`
    - Given some widget such as `android.widget.button` it will return an English description if using a dictionary to make XML classes to natural language descriptions. If the widget is not recognized it will return "Unknown widget component"
- `describeBounds`
    - Attempts to give a natural language description of the bounds of the XML component. Given some screen width, screen height and bounds, it will determine the quadrant that the component is in. 
- `describe_violating`
    - Extracts the attributes used for description from the XML component and calls `describeWidgetComponent` and `describeBounds` assuming a resolution of 1920 x 1080. It uses the widget and text to construct a natural language description of the event.

### Timeline
Engineering Points/Effort: 2 points (2 day's worth of work). This issue was resolved in Sprint 2. 

### Testing - Mac:
```
docker pull itsarunkv/motorease-arm
docker run -it --rm -v $(pwd)/container_files:/container_files itsarunkv/motorease-arm
cd Code
python3 MotorEase.py
```
#### Manual Testing
1. Setup Docker environment
2. Run `python3 MotorEase.py` in the `Code` folder
3. The elements will print as the touch target runs.
4. Here's a screenshot showcasing that the program runs and the violating elements are described in natural language.
![violating_elem](https://github.com/hemkan/MotorEase/assets/68172317/c3ccf0e6-fe5b-42c8-8780-8efa74312615)
