### PR TITLE
Translate interactive components from Android Syntax to English

### DIFF
--- a/Code/detectors/Visual/TouchTarget.py
+++ b/Code/detectors/Visual/TouchTarget.py
@@ -81,7 +81,7 @@ def describeBounds(bounds, height, width):
 
 	return position_description
 
-def describe_violating(xml_element):
+def describe(xml_element, violating_flag):
 	bounds = xml_element.attrib.get('bounds', '')
 	text = xml_element.attrib.get('text', '')
 	component = xml_element.attrib.get('class', '')
@@ -92,7 +92,11 @@ def describe_violating(xml_element):
 	screen_width = 1080
 	position_description = describeBounds(bounds, screen_height, screen_width)
 
-	print("This violating component is a {} with text '{}'.".format(component_str, text))
+	if violating_flag:
+		print("This violating component is a {} with text '{}'.".format(component_str, text))
+	else:
+		print("This interactive component is a {} with text '{}'.".format(component_str, text))
+
 	print(position_description)
 
 def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
@@ -119,9 +123,9 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 						#print(elements)
 						#print(bounds)
 						interactiveElements.append([elements, 1])
-						describe_violating(elem)
+						describe(elem, violating_flag=True)
+						describe(elem, violating_flag=False)
 						violations+=1
-
 					else:
 						
 						im = Image.open(screenshot_path)
@@ -143,13 +147,14 @@ def checkTouchTarget(screenshot_path, xml_path, min_size=(48, 48)):
 										height = data["compos"][i]['height']
 										width = data["compos"][i]['width']
 										if height < 48 or width < 48:
-											describe_violating(elem)
+											describe(elem, violating_flag=True)
 											violations += 1
 											interactiveElements.append([elements, 1])
 										else:
 											nonViolations += 1
 											interactiveElements.append([elements, 0])
 
+										describe(elem, violating_flag=False)
 										#print(violations)
 										#print(nonViolations)
 


### PR DESCRIPTION
### Description:
Currently, the elements that are labeled as interactive are printed out but in XML format. This format can be difficult for users to understand and this PR translates violating elements from Android Syntax to English. This goes hand in hand with the changes made in #23 where violating elements were translated into natural language. Resolves #8.

### Changes:
The changes are made in ` Code/detectors/Visual/TouchTarget.py` and change the description function from `describe_violating` to `describe`. This allows for most the logic to remain the same across element types and has a flag called `violating_flag` that will slightly change the print statement. By using a flag instead of two different functions, we avoid repetition, specifically in calling the description helper functions.

### Timeline
Engineering Points/Effort: 1 points (1 day's worth of work). This issue was resolved in Sprint 2. 

### Testing - Mac:
```
docker pull itsarunkv/motorease-arm
docker run -it --rm -v $(pwd)/container_files:/container_files itsarunkv/motorease-arm
cd Code
python3 MotorEase.py
```
#### Manual Testing
1. Setup Docker environment
2. Run `python3 MotorEase.py` in the `Code` folder
3. The elements will print as the touch target runs.
4. Here's a screenshot showcasing that the program runs and the interactive elements are described in natural language.
![interact_elem](https://github.com/hemkan/MotorEase/assets/68172317/5a422661-84ed-4ea7-a32a-e874aa9a1ab1)

